### PR TITLE
Rename web scraper Posting class to WebPosting

### DIFF
--- a/autojob/scrape.py
+++ b/autojob/scrape.py
@@ -11,7 +11,7 @@ from bs4 import BeautifulSoup
 from flatten_json import flatten as flatten_json  # type: ignore
 
 from .api import Company, api_client
-from .posting import Posting, posting_factory
+from .web_posting import WebPosting, web_posting_factory
 
 
 @dataclass
@@ -110,7 +110,7 @@ class Scrape:
                 if self.args.csv:
                     print(posting.csv_row, file=csv)
 
-    def postings(self) -> Iterator[Posting]:
+    def postings(self) -> Iterator[WebPosting]:
         for company, company_urls in self.generate_companies():
             print(
                 f"Examining postings for {company}"
@@ -122,7 +122,7 @@ class Scrape:
                         continue
                     if self.args.verbose:
                         print("Consider URL", url)
-                    posting = posting_factory(url, company=company)
+                    posting = web_posting_factory(url, company=company)
                     if not posting:
                         continue
                     if self.args.verbose:

--- a/autojob/web_posting.py
+++ b/autojob/web_posting.py
@@ -53,8 +53,10 @@ MIN_NUM = 100
 MAX_NUM = 990_000
 
 
-def posting_factory(url: str, company: str | None = None) -> Posting | None:
-    def _posting_class(url: str) -> type[Posting] | None:
+def web_posting_factory(
+    url: str, company: str | None = None
+) -> WebPosting | None:
+    def _posting_class(url: str) -> type[WebPosting] | None:
         if (
             re.search(r"://boards(\.eu)?\.greenhouse\.io", url)
             or "gh_jid=" in url
@@ -80,7 +82,7 @@ def posting_factory(url: str, company: str | None = None) -> Posting | None:
     return None
 
 
-class Posting:
+class WebPosting:
     def __init__(self, url: str, company: str | None = None) -> None:
         self.url = url
         if company:
@@ -169,7 +171,7 @@ class Posting:
         raise NotImplementedError()
 
 
-class GreenhousePosting(Posting):
+class GreenhousePosting(WebPosting):
     @cached_property
     def title(self) -> str:
         for el in self.soup.find_all("h1", {"class": "app-title"}):
@@ -187,7 +189,7 @@ class GreenhousePosting(Posting):
         return []
 
 
-class LeverPosting(Posting):
+class LeverPosting(WebPosting):
     @cached_property
     def title(self) -> str:
         for el in self.soup.find_all("h2"):


### PR DESCRIPTION
This avoids a naming collision with the API module's Posting class